### PR TITLE
Create: Create dropdown confirming delete

### DIFF
--- a/src/api/service.js
+++ b/src/api/service.js
@@ -3,6 +3,7 @@ import METHODS from "../constants/methods";
 const {
   GET,
   POST,
+  DELETE,
 } = METHODS;
 
 export const getData = async (path) => {
@@ -28,6 +29,27 @@ export const getData = async (path) => {
 export const postData = async (path, resource) => {
   const options = {
     method: POST,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(resource),
+  };
+
+  try {
+    const response = await fetch(`${process.env.REACT_APP_SERVER_URL}${path}`, options);
+
+    const data = response.json();
+
+    return data;
+  } catch (error) {
+    throw new Error(error.message);
+  }
+};
+
+export const deleteData = async (path, resource) => {
+  const options = {
+    method: DELETE,
     headers: {
       "Content-Type": "application/json",
     },

--- a/src/components/ConfirmingDropdown.js
+++ b/src/components/ConfirmingDropdown.js
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+
+import Dropdown from "../components/common/Dropdown";
+import Button from "./common/Button";
+
+import { deleteData } from "../api/service";
+
+import VARIANTS from "../constants/variants";
+import NAMES from "../constants/names";
+
+const {
+  CONFIRM,
+  UTILITY,
+} = VARIANTS;
+
+const {
+  CANCEL,
+  DELETE,
+} = NAMES;
+
+const buttonNames = [CANCEL, DELETE];
+
+export default function ConfirmingDropdown({ path, resource }) {
+  const [isOpen, setOpenStatus] = useState(true);
+
+  const handleClick = ({ target }) => {
+    if (target.textContent === CANCEL) {
+      setOpenStatus(false);
+
+      return;
+    }
+
+    deleteData(path, resource);
+  };
+
+  return (
+    <>
+      {isOpen && (
+        <Dropdown variant={CONFIRM}>
+          <p>정말로 삭제하시겠습니까?</p>
+          <div onClick={handleClick}>
+            {buttonNames.map((name) => <Button variant={UTILITY} key={name}>{name}</Button>)}
+          </div>
+        </Dropdown>
+      )}
+    </>
+  );
+}
+
+ConfirmingDropdown.propTypes = {
+  path: PropTypes.string.isRequired,
+  resource: PropTypes.object,
+};

--- a/src/constants/methods.js
+++ b/src/constants/methods.js
@@ -1,6 +1,7 @@
 const METHODS = {
   GET: "GET",
   POST: "POST",
+  DELETE: "DELETE",
 };
 
 export default METHODS;

--- a/src/constants/names.js
+++ b/src/constants/names.js
@@ -1,5 +1,7 @@
 const NAMES = {
   REGISTRATION: "등록",
+  CANCEL: "취소",
+  DELETE: "삭제",
 };
 
 export default NAMES;


### PR DESCRIPTION
## 스니펫 & 댓글 삭제 확인 dropdown 생성

스니펫 또는 댓글 삭제 버튼 클릭 시 삭제 여부를 다시 한 번 확인하기 위해 보여주는 dropdown입니다.

### <특이사항>

- 없습니다.