### PR TITLE
Refactor: Change login method

### DIFF
--- a/src/components/AppHeader/UserTools/LoginButton.js
+++ b/src/components/AppHeader/UserTools/LoginButton.js
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useHistory } from "react-router";
-import { useQuery } from "react-query";
 
 import Button from "../../common/Button";
 
@@ -14,18 +13,20 @@ export default function LoginButton({ onClick }) {
 
   const history = useHistory();
 
-  const { data, isSuccess } = useQuery(
-    "login",
-    async () => await checkMember(idToken),
-    {
-      enabled: !!idToken,
-    }
-  );
+  if (idToken) {
+    checkMember(idToken).then(({ userId }) => {
+      if (userId) {
+        localStorage.setItem("userId", userId);
 
-  if (isSuccess) {
-    onClick();
+        onClick(true);
 
-    history.push(data.userId ? "/" : "/users/register");
+        history.push("/");
+
+        return;
+      }
+
+      history.push("/users/register");
+    });
   }
 
   const handleLogin = async () => {

--- a/src/components/AppHeader/UserTools/UserTools.js
+++ b/src/components/AppHeader/UserTools/UserTools.js
@@ -12,7 +12,9 @@ const ToolWrapper = styled.div`
 `;
 
 export default function UserTools() {
-  const [isLogin, setLoginStatus] = useState(false);
+  const hasUserId = !!localStorage.getItem("userId");
+
+  const [isLogin, setLoginStatus] = useState(hasUserId);
 
   const handleClick = (boolean) => setLoginStatus(boolean);
 

--- a/src/components/AppHeader/UserTools/UserTools.js
+++ b/src/components/AppHeader/UserTools/UserTools.js
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useQueryClient } from "react-query";
 import styled from "styled-components";
 
 import LoginButton from "./LoginButton";
@@ -13,13 +12,9 @@ const ToolWrapper = styled.div`
 `;
 
 export default function UserTools() {
-  const queryClient = useQueryClient();
+  const [isLogin, setLoginStatus] = useState(false);
 
-  const [isLogin, setLoginStatus] = useState(queryClient.getQueryData("login"));
-
-  const hasUserId = !!queryClient.getQueryData("login")?.userId;
-
-  const handleClick = () => setLoginStatus(hasUserId);
+  const handleClick = (boolean) => setLoginStatus(boolean);
 
   return (
     <ToolWrapper>


### PR DESCRIPTION
## 로그인 방법 수정

페이지 새로고침 시에도 로그인 상태를 유지하기 위해 사용자 정보를 local storage에 저장하는 방법으로 수정하였습니다.

이전에 사용하였던 `useQuery()` 대신 `fetch()`를 사용했습니다.

### <특이사항>

- 없습니다.