### PR TITLE
Refactor: Modify user information page, modify comment list

### DIFF
--- a/src/components/Comment/CommentList.js
+++ b/src/components/Comment/CommentList.js
@@ -5,13 +5,29 @@ import Comment from "./Comment";
 const CommentInputBox = styled.div`
   align-items: center;
   width: 1100px;
-  margin-bottom: 50px;
+  margin-bottom: 200px;
   border: 2px solid #543FD3;
   border-radius: 8px;
 `;
 
+const Message = styled.div`
+  align-items: center;
+  width: 1100px;
+  height: 100px;
+  margin-bottom: 200px;
+  border: 2px solid #543FD3;
+  border-radius: 8px;
+  text-align: center;
+  font-size: 20px;
+  line-height: 100px;
+`;
+
 export default function CommentList({ snippet, userId }) {
-  const { _id, commentList } = snippet;
+  const { _id, commentList, poster } = snippet;
+
+  if (commentList.length === 0) {
+    return <Message>{poster.nickname}님의 게시글에 첫 댓글을 남겨보세요!</Message>;
+  }
 
   return (
     <CommentInputBox>

--- a/src/components/Comment/CommentList.js
+++ b/src/components/Comment/CommentList.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 import Comment from "./Comment";
 
-const CommentInputBox = styled.div`
+const CommentListBox = styled.div`
   align-items: center;
   width: 1100px;
   margin-bottom: 200px;
@@ -30,10 +30,10 @@ export default function CommentList({ snippet, userId }) {
   }
 
   return (
-    <CommentInputBox>
+    <CommentListBox>
       {commentList.map((comment) => (
         <Comment key={_id} data={comment} snippetId={_id} userId={userId} />
       ))}
-    </CommentInputBox>
+    </CommentListBox>
   );
 }

--- a/src/components/RegisterCard/ProfileImage.js
+++ b/src/components/RegisterCard/ProfileImage.js
@@ -32,17 +32,19 @@ const Uploader = styled.input`
   display: none;
 `;
 
-export default function ProfileImage({ imageUrl }) {
+export default function ProfileImage({ imageUrl, canSelectImage = true }) {
   return (
     <Wrapper>
       <ProfileImageTool>
         <Image src={imageUrl || "/images/arbitrary_profile_image.jpeg"} alt="프로필 이미지" width="180" height="180" />
-        <ImageUploader>
-          <label htmlFor="uploader">
-            <img src="/images/image_uploader_icon.png" alt="이미지 첨부" width="45px" height="40px" />
-          </label>
-          <Uploader type="file" id="uploader" accept=".png, .jpg, .jpeg" />
-        </ImageUploader>
+        {canSelectImage &&
+          <ImageUploader>
+            <label htmlFor="uploader">
+              <img src="/images/image_uploader_icon.png" alt="이미지 첨부" width="45px" height="40px" />
+            </label>
+            <Uploader type="file" id="uploader" accept=".png, .jpg, .jpeg" />
+          </ImageUploader>
+        }
       </ProfileImageTool>
     </Wrapper>
   );

--- a/src/components/UserInformationPage/UserInformation.js
+++ b/src/components/UserInformationPage/UserInformation.js
@@ -4,7 +4,7 @@ import styled from "styled-components";
 
 import NotificationBar from "./NotificationBar";
 import FollowingBar from "./FollowingBar";
-import UserTap from "./UserTap";
+import UserTab from "./UserTab";
 import SelectBox from "../AligningSelectBox/AligningSelectBox";
 import SnippetList from "../SnippetList/SnippetList";
 import Button from "../common/Button";
@@ -136,7 +136,7 @@ export default function UserInformation() {
         <FollowingBar width={430} height="100vh">
           <p>This is Following List</p>
         </FollowingBar>
-        {user && <UserTap user={user} />}
+        {user && <UserTab user={user} />}
       </Side>
       <Menu>
         <Button variant="filter" onClick={handleAllClick} children="ALL" />

--- a/src/components/UserInformationPage/UserTab.js
+++ b/src/components/UserInformationPage/UserTab.js
@@ -96,24 +96,24 @@ const Message = styled.p`
   color: var(--color-message);
 `;
 
-export default function UserTap({ user }) {
+export default function UserTab({ user }) {
   const { _id: userId, email, nickname, imageUrl, followerList } = user;
 
   const [failureReason, setFailureReason] = useState();
-  const [editing, setEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
   const reference = useRef();
 
   const loggedInId = localStorage.getItem("userId");
   const canEdit = loggedInId === userId;
 
   const handleEditClick = () => {
-    if (editing) {
-      setEditing(false);
+    if (isEditing) {
+      setIsEditing(false);
 
       return;
     }
 
-    setEditing(true);
+    setIsEditing(true);
   };
 
   const handleSubmitClick = async () => {
@@ -143,7 +143,7 @@ export default function UserTap({ user }) {
     if (response.result === OK) {
       alert(USER_INFORMATION_UPDATED);
 
-      setEditing(false);
+      setIsEditing(false);
     }
   };
 
@@ -151,18 +151,18 @@ export default function UserTap({ user }) {
     <Wrapper>
       <FixedWrapper>
         <BlankBlock />
-        <ProfileImage imageUrl={imageUrl} canSelectImage={editing} />
+        <ProfileImage imageUrl={imageUrl} canSelectImage={isEditing} />
         <Information>
           <NickName>{nickname}</NickName>
-          {(canEdit && !editing) && <EditButton onClick={handleEditClick}>내 정보 수정</EditButton>}
-          {editing && <Input type="text" placeholder="수정할 닉네임을 입력해 주세요." ref={reference} />}
+          {(canEdit && !isEditing) && <EditButton onClick={handleEditClick}>내 정보 수정</EditButton>}
+          {isEditing && <Input type="text" placeholder="수정할 닉네임을 입력해 주세요." ref={reference} />}
           <Message>{failureReason}</Message>
           <Email>{email}</Email>
           <FollowerNumber>구독자 수 : {followerList?.length}</FollowerNumber>
         </Information>
         <ButtonWrapper>
-          {editing && <Button variant="edit" children="수정하기" onClick={handleSubmitClick} />}
-          {editing && <Button variant="edit" children="수정취소" onClick={handleEditClick} />}
+          {isEditing && <Button variant="edit" children="수정하기" onClick={handleSubmitClick} />}
+          {isEditing && <Button variant="edit" children="수정취소" onClick={handleEditClick} />}
         </ButtonWrapper>
       </FixedWrapper>
     </Wrapper>

--- a/src/components/UserInformationPage/UserTap.js
+++ b/src/components/UserInformationPage/UserTap.js
@@ -46,6 +46,16 @@ const NickName = styled.div`
   font-size: 35px;
 `;
 
+const EditButton = styled.button`
+  width: 90px;
+  margin: 10px auto;
+  border: 1px solid var(--color-message);
+  border-radius: 5px;
+  font-size: 15px;
+  color: var(--color-message);
+  cursor: pointer;
+`;
+
 const Input = styled.input`
   display: block;
   width: 230px;
@@ -75,8 +85,10 @@ const FollowerNumber = styled.div`
 `;
 
 const ButtonWrapper = styled.div`
-  margin-left: 160px;
-  margin-bottom: 100px;
+  display: flex;
+  justify-content: space-evenly;
+  width: 250px;
+  margin-left: 85px;
 `;
 
 const Message = styled.p`
@@ -85,12 +97,26 @@ const Message = styled.p`
 `;
 
 export default function UserTap({ user }) {
-  const { email, nickname, imageUrl, followerList } = user;
+  const { _id: userId, email, nickname, imageUrl, followerList } = user;
 
   const [failureReason, setFailureReason] = useState();
+  const [editing, setEditing] = useState(false);
   const reference = useRef();
 
-  const handleButtonClick = async () => {
+  const loggedInId = localStorage.getItem("userId");
+  const canEdit = loggedInId === userId;
+
+  const handleEditClick = () => {
+    if (editing) {
+      setEditing(false);
+
+      return;
+    }
+
+    setEditing(true);
+  };
+
+  const handleSubmitClick = async () => {
     const nickname = reference.current.value;
 
     const validationResult = validateNickname(nickname);
@@ -116,6 +142,8 @@ export default function UserTap({ user }) {
 
     if (response.result === OK) {
       alert(USER_INFORMATION_UPDATED);
+
+      setEditing(false);
     }
   };
 
@@ -123,16 +151,18 @@ export default function UserTap({ user }) {
     <Wrapper>
       <FixedWrapper>
         <BlankBlock />
-        <ProfileImage imageUrl={imageUrl} />
+        <ProfileImage imageUrl={imageUrl} canSelectImage={editing} />
         <Information>
           <NickName>{nickname}</NickName>
-          <Input type="text" placeholder="수정할 닉네임을 입력해 주세요." ref={reference} />
+          {(canEdit && !editing) && <EditButton onClick={handleEditClick}>내 정보 수정</EditButton>}
+          {editing && <Input type="text" placeholder="수정할 닉네임을 입력해 주세요." ref={reference} />}
           <Message>{failureReason}</Message>
           <Email>{email}</Email>
           <FollowerNumber>구독자 수 : {followerList?.length}</FollowerNumber>
         </Information>
         <ButtonWrapper>
-          <Button variant="edit" children="수정하기" onClick={handleButtonClick} />
+          {editing && <Button variant="edit" children="수정하기" onClick={handleSubmitClick} />}
+          {editing && <Button variant="edit" children="수정취소" onClick={handleEditClick} />}
         </ButtonWrapper>
       </FixedWrapper>
     </Wrapper>


### PR DESCRIPTION
## 사용자 정보 페이지 및 댓글 리스트 수정

### 1. 사용자 정보 페이지
- 계정 주인만 볼 수 있는 정보 수정 버튼 생성
- 정보 수정 버튼을 누를 경우에만 다음의 요소가 나타나도록 변경
- 프로필 이미지 변경 아이콘, 닉네임 변경창, 수정하기 버튼, 수정 취소 버튼

### 2. 댓글 리스트
- 해당 게시글에 댓글이 존재하지 않는 경우 '(게시자 닉네임)님의 게시글에 첫 댓글을 남겨보세요!' 메시지가 나타나도록 변경