### PR TITLE
Refactor: Modify to change image and nickname when user information c…

### DIFF
--- a/src/components/RegisterCard/ProfileImage.js
+++ b/src/components/RegisterCard/ProfileImage.js
@@ -22,6 +22,10 @@ const Image = styled.img`
   border-radius: 100%;
 `;
 
+const UploaderImage = styled.img`
+  cursor: pointer;
+`;
+
 const ImageUploader = styled.div`
   position: absolute;
   width: 45px;
@@ -32,15 +36,15 @@ const Uploader = styled.input`
   display: none;
 `;
 
-export default function ProfileImage({ imageUrl, canSelectImage = true, changeImage }) {
+export default function ProfileImage({ imageUrl, canSelectImage = true, changeImage, profileImage }) {
   return (
     <Wrapper>
       <ProfileImageTool>
-        <Image src={imageUrl || "/images/arbitrary_profile_image.jpeg"} alt="프로필 이미지" width="180" height="180" />
+        <Image src={imageUrl || profileImage} alt="프로필 이미지" width="180" height="180" />
         {canSelectImage &&
           <ImageUploader>
             <label htmlFor="uploader">
-              <img src="/images/image_uploader_icon.png" alt="이미지 첨부" width="45px" height="40px" />
+              <UploaderImage src="/images/image_uploader_icon.png" alt="이미지 첨부" width="45px" height="40px" />
             </label>
             <Uploader type="file" id="uploader" accept=".png, .jpg, .jpeg" onChange={changeImage} />
           </ImageUploader>

--- a/src/components/RegisterCard/ProfileImage.js
+++ b/src/components/RegisterCard/ProfileImage.js
@@ -32,7 +32,7 @@ const Uploader = styled.input`
   display: none;
 `;
 
-export default function ProfileImage({ imageUrl, canSelectImage = true }) {
+export default function ProfileImage({ imageUrl, canSelectImage = true, changeImage }) {
   return (
     <Wrapper>
       <ProfileImageTool>
@@ -42,7 +42,7 @@ export default function ProfileImage({ imageUrl, canSelectImage = true }) {
             <label htmlFor="uploader">
               <img src="/images/image_uploader_icon.png" alt="이미지 첨부" width="45px" height="40px" />
             </label>
-            <Uploader type="file" id="uploader" accept=".png, .jpg, .jpeg" />
+            <Uploader type="file" id="uploader" accept=".png, .jpg, .jpeg" onChange={changeImage} />
           </ImageUploader>
         }
       </ProfileImageTool>

--- a/src/components/SnippetList/PreviewSnippet/PreviewSnippet.js
+++ b/src/components/SnippetList/PreviewSnippet/PreviewSnippet.js
@@ -13,7 +13,7 @@ const SnippetBox = styled.div`
   box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.4);
 `;
 
-export default function PreviewSnippet({ data, snippetId }) {
+export default function PreviewSnippet({ data, snippetId, changedProfileImage, changedNickname }) {
   const { _id, poster, language, createdAt, likerList, commentList, code, hashtagList } = data;
   const { _id: posterId, imageUrl, nickname, followerList } = poster;
 
@@ -36,8 +36,8 @@ export default function PreviewSnippet({ data, snippetId }) {
     <SnippetBox>
       <SnippetHeader
         posterId={posterId}
-        profileUrl={imageUrl}
-        nickname={nickname}
+        profileUrl={changedProfileImage || imageUrl}
+        nickname={changedNickname || nickname}
         follower={followerList}
         language={language}
         code={code}

--- a/src/components/UserInformationPage/UserInformation.js
+++ b/src/components/UserInformationPage/UserInformation.js
@@ -90,8 +90,8 @@ const Menu = styled.div`
 export default function UserInformation() {
   const [user, setUser] = useState();
   const [snippets, setSnippets] = useState([]);
-  const [filtered, setFiltered] = useState();
-  const [profileImage, setProfileImage] = useState(user?.imageUrl);
+  const [filtered, setFiltered] = useState(null);
+  const [profileImage, setProfileImage] = useState("");
   const [nickname, setNickname] = useState(user?.nickname);
 
   const { id } = useParams();

--- a/src/components/UserInformationPage/UserInformation.js
+++ b/src/components/UserInformationPage/UserInformation.js
@@ -91,6 +91,8 @@ export default function UserInformation() {
   const [user, setUser] = useState();
   const [snippets, setSnippets] = useState([]);
   const [filtered, setFiltered] = useState();
+  const [profileImage, setProfileImage] = useState(user?.imageUrl);
+  const [nickname, setNickname] = useState(user?.nickname);
 
   const { id } = useParams();
 
@@ -108,6 +110,14 @@ export default function UserInformation() {
 
     fetchData();
   }, [id]);
+
+  const changeProfileImage = (image) => {
+    setProfileImage(image);
+  };
+
+  const changeNickname = (nickname) => {
+    setNickname(nickname);
+  };
 
   const handleFilterClick = (filter) => {
     let filteredSnippets;
@@ -138,7 +148,7 @@ export default function UserInformation() {
         <FollowingBar width={430} height="100vh">
           <p>This is Following List</p>
         </FollowingBar>
-        {user && <UserTab user={user} />}
+        {user && <UserTab user={user} changeUserImage={changeProfileImage} changeNickname={changeNickname} changedNickname={nickname} />}
       </Side>
       <Menu>
         <Button variant="filter" onClick={() => handleFilterClick("all")} children="ALL" />
@@ -146,7 +156,7 @@ export default function UserInformation() {
         <Button variant="filter" onClick={() => handleFilterClick("saved")} children="SAVED" />
         <SelectBox />
       </Menu>
-      <UserSnippetList snippets={filtered} />
+      <UserSnippetList snippets={filtered} changedProfileImage={profileImage} changedNickname={nickname} />
     </Wrapper>
   );
 }

--- a/src/components/UserInformationPage/UserSnippetList.js
+++ b/src/components/UserInformationPage/UserSnippetList.js
@@ -11,12 +11,12 @@ const ListBox = styled.div`
   width: 700px;
 `;
 
-export default function UserSnippetList({ snippets }) {
+export default function UserSnippetList({ snippets, changedProfileImage, changedNickname }) {
   return (
     <Wrapper>
       <ListBox>
         {snippets && snippets.map((snippet) => (
-          <PreviewSnippet key={snippet._id} data={snippet} snippetId={snippet._id} />
+          <PreviewSnippet key={snippet._id} data={snippet} snippetId={snippet._id} changedProfileImage={changedProfileImage} changedNickname={changedNickname} />
         ))}
       </ListBox>
     </Wrapper>


### PR DESCRIPTION
## 사용자 정보 변경 시 이미지 및 닉네임 변경

- 사용자 정보 수정이 이루어질 경우, 해당 페이지 내에 존재하는 모든 이미지와 닉네임이 변경되도록 수정하였습니다.
- 사용자 정보 변경 과정에서 변경할 이미지를 선택한 시점에 유저탭의 이미지가 미리 바뀌어 보이도록 수정하였습니다.
- 사용자 정보 수정 시 이미지를 선택하지 않으면 기본 이미지로 변경되는 오류를 수정하였습니다.