### PR TITLE
Refactor: Modify commentlist to rerender after create or delete comment

### DIFF
--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -57,7 +57,7 @@ const DeleteButton = styled.div`
   cursor: pointer;
 `;
 
-export default function Comment({ data, snippetId, userId }) {
+export default function Comment({ data, snippetId, userId, updateCommentList }) {
   const { _id: commentId, creator, content, createdAt } = data;
   const dateFormat = getDate(createdAt);
   const isCreator = creator._id === userId;
@@ -67,6 +67,8 @@ export default function Comment({ data, snippetId, userId }) {
 
     if (response.result === OK) {
       alert(DELETE_COMMENT_SUCCEEDED);
+
+      updateCommentList(true);
     }
   };
 

--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { deleteComment } from "../../api/service";
 
@@ -7,6 +7,10 @@ import {
   OK,
 } from "../../constants/messages";
 import getDate from "../../utils/getDate";
+
+const setPadding = (size) => css`
+  padding-right: ${size};
+`;
 
 const Wrapper = styled.div`
   display: flex;
@@ -46,6 +50,12 @@ const Date = styled.div`
   color: gray;
   font-size: 15px;
   font-weight: bold;
+
+  ${({ isCreator }) => {
+    if (!isCreator) {
+      return setPadding("17px");
+    }
+  }}
 `;
 
 const DeleteButton = styled.div`
@@ -77,7 +87,7 @@ export default function Comment({ data, snippetId, userId, updateCommentList }) 
       <UserImage src={creator.imageUrl} alt="프로필 이미지" width="25px" height="25px" />
       <UserName>{creator.nickname}</UserName>
       <Content>{content}</Content>
-      <Date>{dateFormat}</Date>
+      <Date isCreator={isCreator}>{dateFormat}</Date>
       {isCreator && <DeleteButton onClick={handleOnclick}>X</DeleteButton>}
     </Wrapper>
   );

--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -2,11 +2,12 @@ import styled, { css } from "styled-components";
 
 import { deleteComment } from "../../api/service";
 
+import getDate from "../../utils/getDate";
+
 import {
   DELETE_COMMENT_SUCCEEDED,
   OK,
 } from "../../constants/messages";
-import getDate from "../../utils/getDate";
 
 const setPadding = (size) => css`
   padding-right: ${size};

--- a/src/components/Comment/CommentBox.js
+++ b/src/components/Comment/CommentBox.js
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import styled from "styled-components";
 import CommentInput from "./CommentInputBox";
 import CommentList from "./CommentList";
@@ -7,15 +8,15 @@ const Wrapper = styled.div`
   margin: 15px auto;
 `;
 
-export default function CommentBox({ snippet }) {
+export default function CommentBox({ snippet, updateCommentList }) {
   const { _id } = snippet;
 
   const userId = localStorage.getItem("userId");
 
   return (
     <Wrapper>
-      <CommentInput snippetId={_id} userId={userId} />
-      <CommentList snippet={snippet} userId={userId} />
+      <CommentInput snippetId={_id} userId={userId} updateCommentList={updateCommentList} />
+      <CommentList snippet={snippet} userId={userId} updateCommentList={updateCommentList} />
     </Wrapper>
   );
 }

--- a/src/components/Comment/CommentBox.js
+++ b/src/components/Comment/CommentBox.js
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import styled from "styled-components";
 import CommentInput from "./CommentInputBox";
 import CommentList from "./CommentList";

--- a/src/components/Comment/CommentInputBox.js
+++ b/src/components/Comment/CommentInputBox.js
@@ -102,7 +102,7 @@ export default function CommentInput({ snippetId, userId, updateCommentList }) {
         <>
           <UserImage src={user.imageUrl} alt="프로필 이미지" width="25px" height="25px" />
           <UserName>{user.nickname}</UserName>
-          <InputArea onChange={handleInputChange} />
+          <InputArea onChange={handleInputChange} value={inputText} />
           <SubmitIcon src="/images/send_button.png" alt="프로필 이미지" width="25px" height="25px" onClick={() => handleButtonClick()} />
         </>
       }

--- a/src/components/Comment/CommentInputBox.js
+++ b/src/components/Comment/CommentInputBox.js
@@ -6,6 +6,7 @@ import { createComment, getUserData } from "../../api/service";
 import {
   INSUFFICIENT_COMMENT_LENGTH,
   CREATE_COMMENT_SUCCEEDED,
+  COMMENT_INPUT_BLOCKED,
   OK,
 } from "../../constants/messages";
 
@@ -46,7 +47,7 @@ const InputArea = styled.input`
   outline: none;
 `;
 
-const SearchIcon = styled.img`
+const SubmitIcon = styled.img`
   width: 30px;
   height: 25px;
   margin-top: 1px;
@@ -54,7 +55,7 @@ const SearchIcon = styled.img`
   cursor: pointer;
 `;
 
-export default function CommentInput({ snippetId, userId }) {
+export default function CommentInput({ snippetId, userId, updateCommentList }) {
   const [user, setUser] = useState({});
   const [inputText, setInputText] = useState("");
 
@@ -66,7 +67,7 @@ export default function CommentInput({ snippetId, userId }) {
     }
 
     getUser();
-  }, []);
+  }, [userId]);
 
   const handleInputChange = (event) => {
     setInputText(event.target.value);
@@ -90,6 +91,7 @@ export default function CommentInput({ snippetId, userId }) {
     if (response.result === OK) {
       alert(CREATE_COMMENT_SUCCEEDED);
 
+      updateCommentList(true);
       onReset();
     }
   };
@@ -101,9 +103,10 @@ export default function CommentInput({ snippetId, userId }) {
           <UserImage src={user.imageUrl} alt="프로필 이미지" width="25px" height="25px" />
           <UserName>{user.nickname}</UserName>
           <InputArea onChange={handleInputChange} />
-          <SearchIcon src="/images/send_button.png" alt="프로필 이미지" width="25px" height="25px" onClick={() => handleButtonClick()} />
+          <SubmitIcon src="/images/send_button.png" alt="프로필 이미지" width="25px" height="25px" onClick={() => handleButtonClick()} />
         </>
       }
+      {!user && <div>{COMMENT_INPUT_BLOCKED}</div>}
     </CommentInputBox>
   );
 }

--- a/src/components/Comment/CommentList.js
+++ b/src/components/Comment/CommentList.js
@@ -22,7 +22,7 @@ const Message = styled.div`
   line-height: 100px;
 `;
 
-export default function CommentList({ snippet, userId }) {
+export default function CommentList({ snippet, userId, updateCommentList }) {
   const { _id, commentList, poster } = snippet;
 
   if (commentList.length === 0) {
@@ -32,7 +32,7 @@ export default function CommentList({ snippet, userId }) {
   return (
     <CommentListBox>
       {commentList.map((comment) => (
-        <Comment key={_id} data={comment} snippetId={_id} userId={userId} />
+        <Comment key={comment._id} data={comment} snippetId={_id} userId={userId} updateCommentList={updateCommentList} />
       ))}
     </CommentListBox>
   );

--- a/src/components/SnippetDetailPage/SnippetDetailPage.js
+++ b/src/components/SnippetDetailPage/SnippetDetailPage.js
@@ -15,6 +15,7 @@ const SnippetBox = styled.div`
 
 export default function SnippetDetailPage() {
   const [snippet, setSnippet] = useState(null);
+  const [isCommentChanged, setIsCommentChanged] = useState(false);
 
   const { id } = useParams();
 
@@ -25,15 +26,20 @@ export default function SnippetDetailPage() {
       const { snippet } = data;
 
       setSnippet(snippet);
+      setIsCommentChanged(false);
     })();
-  }, [id]);
+  }, [id, isCommentChanged]);
+
+  const updateCommentList = () => {
+    setIsCommentChanged(true);
+  };
 
   return (
     <>
       <SnippetBox>
         {snippet && <DetailSnippet snippet={snippet} />}
       </SnippetBox>
-      {snippet && <CommentBox snippet={snippet} />}
+      {snippet && <CommentBox snippet={snippet} updateCommentList={updateCommentList} />}
     </>
   );
 };

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -26,6 +26,7 @@ const UNKNOWN_LIKE_STATUS = "현재 좋아요 상태가 확인되지 않았습�
 const NOT_FOUND_USER = "존재하지 않는 사용자입니다.";
 const NOT_FOUND_SNIPPET = "존재하지 않는 게시물입니다.";
 const FORBIDDEN_FOLLOWING = "다른 사용자만 팔로우할 수 있습니다.";
+const COMMENT_INPUT_BLOCKED = "로그인 후 댓글을 작성할 수 있습니다.";
 const OK = "ok";
 
 export {
@@ -57,5 +58,6 @@ export {
   NOT_FOUND_USER,
   NOT_FOUND_SNIPPET,
   FORBIDDEN_FOLLOWING,
+  COMMENT_INPUT_BLOCKED,
   OK,
 };


### PR DESCRIPTION
## 댓글 관련 컴포넌트 리팩토링
- 댓글 작성 및 삭제 시 댓글 목록이 다시 렌더링 되도록 수정
- 댓글 작성 이후 input 란에 이전에 작성한 댓글이 남아있던 문제 수정
- x 버튼이 보이는 댓글의 날짜가 그렇지 않은 댓글의 날짜와 달리 위치가 밀린 채로 보이는 문제 수정
- map으로 반복되는 Comment 컴포넌트 각각에 댓글 데이터 자체의 id 부여